### PR TITLE
WP-2591: response.stream - attempt find size of tempfile streams

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -627,7 +627,7 @@ class Response(Storage):
             try:
                 headers['Content-Length'] = os.fstat(stream.fileno()).st_size
             except (AttributeError, OSError, TypeError):
-                if filename and filename != '<fdopen>':
+                if filename:
                     try:
                         headers['Content-Length'] = os.stat(filename).st_size
                     except OSError:

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -627,7 +627,7 @@ class Response(Storage):
             try:
                 headers['Content-Length'] = os.fstat(stream.fileno()).st_size
             except (AttributeError, OSError, TypeError):
-                if filename:
+                if filename and filename != '<fdopen>':
                     try:
                         headers['Content-Length'] = os.stat(filename).st_size
                     except OSError:

--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -626,12 +626,8 @@ class Response(Storage):
         if 'content-length' not in keys:
             try:
                 headers['Content-Length'] = os.fstat(stream.fileno()).st_size
-            except (AttributeError, OSError, TypeError):
-                if filename:
-                    try:
-                        headers['Content-Length'] = os.stat(filename).st_size
-                    except OSError:
-                        pass
+            except OSError:
+                pass
 
         env = request.env
         # Internet Explorer < 9.0 will not allow downloads over SSL unless caching is enabled


### PR DESCRIPTION
Calling .flush() makes sure there isn't something hanging out in `stream`'s buffer.

.tell() gets the current position in the file, if it's a file. If that method isn't available, attempting to call it should throw an AttributeError. If for whatever reason the `stream` _does_ have a .tell() but it doesn't return a data type we expect, we don't proceed to use it or attempt to set the Content-Length. Not sure that this scenario is all that likely, but better safe than sorry, right?

Assuming the check on .tell()'s results are good, set the Content-Length, and seek to `stream`'s original position. Don't want to make assumptions on that at this point.