### PR TITLE
WP-2591 update: allow cStringIO.StringIO

### DIFF
--- a/gluon/globals.py
+++ b/gluon/globals.py
@@ -626,7 +626,7 @@ class Response(Storage):
         if 'content-length' not in keys:
             try:
                 headers['Content-Length'] = os.fstat(stream.fileno()).st_size
-            except OSError:
+            except (AttributeError, OSError):
                 pass
 
         env = request.env


### PR DESCRIPTION
Specifically, web2py's .../controllers/default.py - download() streams a cStringIO.StringIO object for user profile pics.
This causes an uncaught exception, AttributeError, to be thrown because said type does not have a `fileno` attribute.

More generally, I wonder if all upload fields are served with that object type.